### PR TITLE
Update settings.sh: added edit of ~/.instantsession

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -719,6 +719,7 @@ toggleiconf() {
 instantossettings() {
     menu '>>h instantOS settings'
     menu ':b Edit Autostart script'
+    menu ':b Edit Session Environment'
     menu ':b Theming'
     menu ':y Potato'
     menu ':b 𧻓Animations'
@@ -736,7 +737,7 @@ instantossettings() {
 
     CHOICE="$(meta instantossettings menu | sidebar)"
     case $CHOICE in
-    *script)
+    *Autostart*)
         if ! [ -e ~/.config/instantos/autostart.sh ]; then
             mkdir -p ~/.config/instantos
             if [ -e ~/.instantautostart ]; then
@@ -749,6 +750,15 @@ instantossettings() {
             fi
         fi
         instantutils open editor ~/.config/instantos/autostart.sh &
+        ;;
+    *Environment)
+        if ! [ -e ~/.instantsession ]; then
+            echo "# instantOS Session Environment Script
+# This script gets sourced when $(whoami) logs in
+# Add environment variables that should be available to all processes executed from your desktop session." > \
+                ~/.instantsession
+        fi
+        instantutils open editor ~/.instantsession &
         ;;
     *Theming)
         toggleiconf notheming "enable instantOS theming?" i


### PR DESCRIPTION
Added an item to edit `~/.instantsession`, since it's arguably (almost) as important as the Autostart script. 
Especially for "not-desktop-environments" the setting of xsession-wide persistent env vars is a recurring configuration problem for many new users (especially those coming from e.g. `gnome` or `kde`), and the existence and sourcing of `~/.instantsession` in this context is insufficiently clear to new users, which would be additionally solved by this feature.