### PR TITLE
partial yet functional support for variants [switcher]

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1301,9 +1301,12 @@ keyboardsettings() {
         LAYOUTFILE="$HOME/.config/instantos/keylayoutlist"
         if ! [ -e "$LAYOUTFILE" ]; then
             mkdir -p ~/.config/instantos
-            setxkbmap -query | grep layout | grep -o '..$' >"$LAYOUTFILE"
+            setxkbmap -query | grep layout | grep -o '..$' >"$LAYOUTFILE" # This has to generate with a default variant, probably the best option is to store that in setting.db
         fi
-        LAYOUTLIST="$(imenu -E 'keyboard layout list' 'localectl list-x11-keymap-layouts | imenu -l' <"$LAYOUTFILE")"
+        LAYOUTLIST="$(imenu -E 'keyboard layout list' 'x=$(localectl list-x11-keymap-layouts | imenu -l); \
+            echo $x" ("$(localectl list-x11-keymap-variants $x | imenu -l)")"' <"$LAYOUTFILE")"
+        LAYOUTLIST=${LAYOUTLIST// (/:}
+        LAYOUTLIST=${LAYOUTLIST//)/}
         if [ -z "$LAYOUTLIST" ]; then
             rm ~/.config/instantos/layouts
         else


### PR DESCRIPTION
With this added, layout switcher will ask for a variant after choosing a layout, in the keylayoutlist it be stored as [layout]:[variant], that's already recognized/supported by the keyboard layout switcher, and my friend Tomix made a PR there too for this to finish it up
The only thing after both PR's that's left is, as the comment in the code says - when creating a default keylayoutlist, it has to include the variant user choosed as default.
 