### PR TITLE
add flashfocus integration to appearance settings

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1289,6 +1289,7 @@ appearancesettings() {
     menu ':b Enable compositing'
     menu ':b 並V-Sync'
     menu ':b Blur'
+    menu ':b Flash windows on focus'
     menu ':b Autotheming'
     menu ':b Back'
 
@@ -1332,6 +1333,18 @@ appearancesettings() {
             pkill picom
             sleep 0.3
             ipicom &
+        fi
+        appearancesettings
+        ;;
+    *focus)
+        toggleiconf flashfocus "enable flashing windows on focus?" i
+        
+        pkill flashfocus >/dev/null |:
+        while pgrep flashfocus; do sleep 0.1; done
+        
+        if ! iconf -i flashfocus; then
+            instantinstall flashfocus || exit 1
+            flashfocus &
         fi
         appearancesettings
         ;;


### PR DESCRIPTION
Add an option to Appearance Settings for enabling/disabling `flashfocus`, installing it using `instantinstall` if necessary.

I didn't write `flashfocus`, but I've found it very useful. It "flashes" windows by temporarily lowering their opacity when focused, making it much easier to follow what window you just focused while being light on resources and still looking good. Of course, it doesn't work without compositing enabled.