### PR TITLE
Add user account management section to instantSETTINGS

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1258,6 +1258,10 @@ usersettings() {
 
         instantsudo useradd "$USER_TO_CREATE" \
         || imenu -e "failed to create user: useradd exited ($CODE)"
+
+        printf "created user '$USER_TO_CREATE'\n\
+make sure to change its password!" \
+        | imenu -M
         
         unset USER_TO_CREATE
         usersettings

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -69,5 +69,5 @@ list_func_names() {
 
 list_users() {
     # list real human users (uid above 1000, not 'nobody')  
-    awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd | imenu -l
+    awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd
 }

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -66,3 +66,8 @@ list_func_names() {
         typeset +f | sed 's/().*$//'
     fi
 }
+
+list_users() {
+    # list real human users (uid above 1000, not 'nobody')  
+    awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd | imenu -l
+}


### PR DESCRIPTION
I saw someone in the #help channel on the instantOS Discord server ask if there's any feature to add users via GUI, so I made it.

So far it can:
- Change a user's password
- Create a new user
- Delete a user

If it's not considered outside the scope of instantSETTINGS, I could also add group management features and the ability to allow/disallow sudo privileges to a user.