### PR TITLE
Check if instantOS development tools are installed

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -1026,7 +1026,13 @@ instantossettings() {
         fi
         ;;
     *tools)
-        imenu -c "install instantOS development tools?" || exit
+        DEVUTILDIR=/usr/local/share/instanttools/
+        if [ ! -d "$DEVUTILDIR" ]; then
+            imenu -c "install instantOS development tools?" || exit
+        else
+            imenu -m "InstantOS development tools are already installed"
+            exit
+        fi
         checkinternet || {
             imenu -e "internet is required"
             exit 1


### PR DESCRIPTION
Checks if the instanttools directory  /usr/local/share/instanttools/ exist and shows the message "InstantOS development tools are already installed".

I know only checking if the directory exist is not the best but I haven't gotten a functioning other idea.