### PR TITLE
append " $@" to application defaults

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -275,7 +275,7 @@ $(grep -o '^[^:][^:]*' /usr/share/instantsettings/data/default/"$1" | sed 's/^/:
     *Custom)
         CUSTOMAPP="$(imenu -i "default $1")"
         [ -z "$CUSTOMAPP" ] && return 1
-        iconf "$1" "$CUSTOMAPP"
+        iconf "$1" "$CUSTOMAPP \$@"
         return 0
         ;;
     *Back)


### PR DESCRIPTION
This change fixes an issue where setting an application default to something with multiple arguments (e.g. editor = `st -e nano`) will open as if arguments had not been given to it (e.g. `instantutils open editor testfile` opens nano in a blank buffer).

Appending ` $@` to the end of the defaults, as in `st -e nano $@`, fixes this issue.