### PR TITLE
add option to change refresh rate

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -383,6 +383,7 @@ displaysettings() {
     menu ':b Autodetect monitor docking'
     menu ':b External screen'
     menu ':b HiDPI'
+    menu ':b 累Change refresh rate'
     menu ':b Keep screen on when locked'
 
     CHOICE="$({
@@ -392,7 +393,7 @@ displaysettings() {
         echo ':b Back'
     } | sidebar)"
     case $CHOICE in
-    *settings)
+    *display*)
         arandr &
         ;;
     *brightness)
@@ -436,6 +437,17 @@ displaysettings() {
         instantdpi
         xrdb ~/.Xresources
         ;;
+	*refresh*)
+		REFRESH=$(imenu -i 'enter refresh rate (default is 60)')
+		[ -z "$REFRESH" ] && return
+
+		xrandr -r "$REFRESH" && {
+			confirm 10 'confirm refresh rate? (timeout after 10 seconds)' || xrandr -r 60
+		} || {
+		    imenu -e "unable to set ${REFRESH}Hz refresh rate"
+		}
+		displaysettings
+		;;
     *locked)
         toggleiconf nolocktimeout "keep monitor on when the screen is locked?"
         displaysettings

--- a/utils/functions.sh
+++ b/utils/functions.sh
@@ -71,3 +71,11 @@ list_users() {
     # list real human users (uid above 1000, not 'nobody')  
     awk -F: '$3 >= 1000 && $1 != "nobody" {print $1}' /etc/passwd
 }
+
+timeout() { imenu -m "$2" | $(read -t $1 || echo pkill instantmenu); }
+
+confirm() {
+    result=$(timeout "${1:-5}" "${2:-timeout}" 2>&1)
+    [ "$result" = 'Terminated' ] && return 1 || return 0
+}
+


### PR DESCRIPTION
This PR adds an option under `Display` to specify the display's refresh rate. It does not support setting completely *arbitrary* refresh rates (as creating custom resolutions on the fly can be...problematic), only those reported by `xrandr`.

To support this, the PR also adds two functions:
- `confirm` : display a message (`$2`) to the user and prompt them to press 'OK', exiting with code 1 after `$1` seconds if the user doesn't respond
- `timeout` : backend function for `confirm`